### PR TITLE
Spring Security Filter에서 사용가능하도록 수정

### DIFF
--- a/src/main/java/com/example/weatherwear/common/exception/NotFoundDataException.java
+++ b/src/main/java/com/example/weatherwear/common/exception/NotFoundDataException.java
@@ -1,10 +1,8 @@
 package com.example.weatherwear.common.exception;
 
-/**
- * 해당 데이터를 조회 할 수 없음
- */
+/** 해당 데이터를 조회 할 수 없음 */
 public class NotFoundDataException extends RuntimeException {
-    public NotFoundDataException(String message) {
-        super(message);
-    }
+  public NotFoundDataException(String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/example/weatherwear/common/exception/handler/ExceptionResponse.java
+++ b/src/main/java/com/example/weatherwear/common/exception/handler/ExceptionResponse.java
@@ -1,0 +1,31 @@
+package com.example.weatherwear.common.exception.handler;
+
+import java.io.IOException;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ExceptionResponse {
+  /** 예외 반환 매서드 */
+  public static void createExceptionResponse(
+      int httpStatus, HttpServletRequest request, HttpServletResponse response, String message) {
+    final String path = request.getRequestURI();
+    log.error("Path: {}, Status: {}, Exception: {}", path, httpStatus, message);
+
+    final HttpErrorInfo errorInfo = new HttpErrorInfo(httpStatus, path, message);
+    final ObjectMapper mapper = new ObjectMapper();
+
+    try {
+      response.setContentType("application/json; charset=UTF-8");
+      response.getWriter().write(mapper.writeValueAsString(errorInfo));
+      response.setStatus(httpStatus);
+    } catch (IOException e) {
+      log.error("응답 작성 실패: {}", e.getMessage(), e);
+    }
+  }
+}

--- a/src/main/java/com/example/weatherwear/common/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/weatherwear/common/exception/handler/GlobalExceptionHandler.java
@@ -1,16 +1,14 @@
 package com.example.weatherwear.common.exception.handler;
 
-import java.nio.file.AccessDeniedException;
 import java.text.MessageFormat;
 import java.util.List;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.AuthenticationException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -29,96 +27,114 @@ public class GlobalExceptionHandler {
 
   //    404
   @ExceptionHandler(NoHandlerFoundException.class)
-  public ResponseEntity<HttpErrorInfo> handleNotFound(
-      NoHandlerFoundException ex, HttpServletRequest request) {
+  public void handleNotFound(
+      NoHandlerFoundException ex, HttpServletRequest request, HttpServletResponse response) {
+
+    int httpStatus = HttpStatus.NOT_FOUND.value();
     String message = "해당 경로를 찾을 수 없습니다.";
-    return createExceptionResponse(HttpStatus.NOT_FOUND, request, message);
+    ExceptionResponse.createExceptionResponse(httpStatus, request, response, message);
   }
 
   //    405
   @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
-  public ResponseEntity<HttpErrorInfo> handleMethodNotAllowed(
-      HttpRequestMethodNotSupportedException ex, HttpServletRequest request) {
+  public void handleMethodNotAllowed(
+      HttpRequestMethodNotSupportedException ex,
+      HttpServletRequest request,
+      HttpServletResponse response) {
+
+    int httpStatus = HttpStatus.METHOD_NOT_ALLOWED.value();
     String message = "해당 요청을 처리 할 수 없습니다.";
-    return createExceptionResponse(HttpStatus.METHOD_NOT_ALLOWED, request, message);
+    ExceptionResponse.createExceptionResponse(httpStatus, request, response, message);
   }
 
-  //    403
-  @ExceptionHandler(AccessDeniedException.class)
-  public ResponseEntity<HttpErrorInfo> handleAccessDeniedException(
-      AccessDeniedException ex, HttpServletRequest request) {
-    String message = "접근이 거부되었습니다.";
-    return createExceptionResponse(HttpStatus.FORBIDDEN, request, message);
-  }
-
-  //    401
-  @ExceptionHandler(AuthenticationException.class)
-  public ResponseEntity<HttpErrorInfo> handleAuthenticationException(
-      AuthenticationException ex, HttpServletRequest request) {
-    String message = "인증이 필요합니다.";
-    return createExceptionResponse(HttpStatus.UNAUTHORIZED, request, message);
-  }
+  //  해당 예외는 Spring Security에서 처리해야 할 것 같아 주석 처리
+  //  //    403
+  //  @ExceptionHandler(AccessDeniedException.class)
+  //  public ResponseEntity<HttpErrorInfo> handleAccessDeniedException(
+  //      AccessDeniedException ex, HttpServletRequest request) {
+  //    String message = "접근이 거부되었습니다.";
+  //    return createExceptionResponse(HttpStatus.FORBIDDEN, request, message);
+  //  }
+  //
+  //  //    401
+  //  @ExceptionHandler(AuthenticationException.class)
+  //  public ResponseEntity<HttpErrorInfo> handleAuthenticationException(
+  //      AuthenticationException ex, HttpServletRequest request) {
+  //    String message = "인증이 필요합니다.";
+  //    return createExceptionResponse(HttpStatus.UNAUTHORIZED, request, message);
+  //  }
 
   //    HTTP 요청 매개변수 누락
   @ExceptionHandler(MissingServletRequestParameterException.class)
-  public ResponseEntity<HttpErrorInfo> handlerMissingServletRequestParameterException(
-      MissingServletRequestParameterException ex, HttpServletRequest request) {
+  public void handlerMissingServletRequestParameterException(
+      MissingServletRequestParameterException ex,
+      HttpServletRequest request,
+      HttpServletResponse response) {
+
+    int httpStatus = HttpStatus.METHOD_NOT_ALLOWED.value();
+
     String parameterName = ex.getParameterName();
     String message = MessageFormat.format("{0}의 값이 누락되었습니다.", parameterName);
 
-    return createExceptionResponse(HttpStatus.BAD_REQUEST, request, message);
+    ExceptionResponse.createExceptionResponse(httpStatus, request, response, message);
   }
 
   //    유효성 검사 실패
   @ExceptionHandler(MethodArgumentNotValidException.class)
-  public ResponseEntity<HttpErrorInfo> handlerMethodArgumentNotValidException(
-      MethodArgumentNotValidException ex, HttpServletRequest request) {
+  public void handlerMethodArgumentNotValidException(
+      MethodArgumentNotValidException ex,
+      HttpServletRequest request,
+      HttpServletResponse response) {
+
+    int httpStatus = HttpStatus.BAD_REQUEST.value();
+
     List<FieldError> fieldErrors = ex.getBindingResult().getFieldErrors();
     String message =
         fieldErrors.stream()
             .map(error -> error.getField() + ": " + error.getDefaultMessage())
             .toString();
 
-    return createExceptionResponse(HttpStatus.BAD_REQUEST, request, message);
+    ExceptionResponse.createExceptionResponse(httpStatus, request, response, message);
   }
 
   //    해당 데이터를 조회 할 수 없음
   @ExceptionHandler(NotFoundDataException.class)
-  public ResponseEntity<HttpErrorInfo> handlerNotFoundDataException(
-      NotFoundDataException ex, HttpServletRequest request) {
+  public void handlerNotFoundDataException(
+      NotFoundDataException ex, HttpServletRequest request, HttpServletResponse response) {
+
+    int httpStatus = HttpStatus.BAD_REQUEST.value();
     String message = ex.getMessage();
-    return createExceptionResponse(HttpStatus.BAD_REQUEST, request, message);
+    ExceptionResponse.createExceptionResponse(httpStatus, request, response, message);
   }
 
   //    DB 접근 예외
   @ExceptionHandler(DataAccessException.class)
-  public ResponseEntity<HttpErrorInfo> handleDataAccessException(
-      DataAccessException ex, HttpServletRequest request) {
+  public void handleDataAccessException(
+      DataAccessException ex, HttpServletRequest request, HttpServletResponse response) {
+
+    int httpStatus = HttpStatus.BAD_REQUEST.value();
     String message = "DB 접근 예외가 발생했습니다.";
-    return createExceptionResponse(HttpStatus.BAD_REQUEST, request, message);
+    ExceptionResponse.createExceptionResponse(httpStatus, request, response, message);
   }
 
   //    DB 무결성 재약 조건 위배
   @ExceptionHandler(DataIntegrityViolationException.class)
-  public ResponseEntity<HttpErrorInfo> handlerDataIntegrityViolationException(
-      DataIntegrityViolationException ex, HttpServletRequest request) {
+  public void handlerDataIntegrityViolationException(
+      DataIntegrityViolationException ex,
+      HttpServletRequest request,
+      HttpServletResponse response) {
+
+    int httpStatus = HttpStatus.BAD_REQUEST.value();
     String message = ex.getMessage();
-    return createExceptionResponse(HttpStatus.SERVICE_UNAVAILABLE, request, message);
+    ExceptionResponse.createExceptionResponse(httpStatus, request, response, message);
   }
 
   //    모든 예외 처리
   @ExceptionHandler(Exception.class)
-  public ResponseEntity<HttpErrorInfo> handleGenericException(
-      Exception ex, HttpServletRequest request) {
+  public void handleGenericException(
+      Exception ex, HttpServletRequest request, HttpServletResponse response) {
+    int httpStatus = HttpStatus.INTERNAL_SERVER_ERROR.value();
     String message = "알 수 없는 오류가 발생했습니다.";
-    return createExceptionResponse(HttpStatus.INTERNAL_SERVER_ERROR, request, message);
-  }
-
-  private ResponseEntity<HttpErrorInfo> createExceptionResponse(
-      HttpStatus httpStatus, HttpServletRequest request, String message) {
-    final String path = request.getRequestURI();
-
-    log.error("Path: {}, Status: {}, Exception: {}", path, httpStatus.value(), message);
-    return ResponseEntity.status(httpStatus).body(new HttpErrorInfo(httpStatus, path, message));
+    ExceptionResponse.createExceptionResponse(httpStatus, request, response, message);
   }
 }

--- a/src/main/java/com/example/weatherwear/common/exception/handler/HttpErrorInfo.java
+++ b/src/main/java/com/example/weatherwear/common/exception/handler/HttpErrorInfo.java
@@ -1,21 +1,21 @@
 package com.example.weatherwear.common.exception.handler;
 
-import lombok.Getter;
-import org.springframework.http.HttpStatus;
-
+import java.io.Serializable;
 import java.time.ZonedDateTime;
 
-@Getter
-public class HttpErrorInfo {
-    private final ZonedDateTime timestamp;
-    private final int status;
-    private final String error;
-    private final String path;
+import lombok.Getter;
 
-    public HttpErrorInfo(HttpStatus httpStatus, String path, String message) {
-        timestamp = ZonedDateTime.now();
-        this.status = httpStatus.value();
-        this.path = path;
-        this.error = message;
-    }
+@Getter
+public class HttpErrorInfo implements Serializable {
+  private final String timestamp;
+  private final int status;
+  private final String error;
+  private final String path;
+
+  public HttpErrorInfo(int httpStatus, String path, String message) {
+    this.timestamp = ZonedDateTime.now().toString();
+    this.status = httpStatus;
+    this.path = path;
+    this.error = message;
+  }
 }


### PR DESCRIPTION
기존에 예외 처리 방법에서는 Spring Security Filter에서 사용하기 위해 불편했던 점을 수정했습니다.
```
ExceptionResponse.createExceptionResponse(httpStatus, request, response, message);
```
해당 메서드를 실행함으로써 response에 오류 정보 (HttpErrorInfo)를 전달합니다.

```
public static void createExceptionResponse(int httpStatus, HttpServletRequest request, HttpServletResponse response, String message) {
  final String path = request.getRequestURI();
  log.error("Path: {}, Status: {}, Exception: {}", path, httpStatus, message);

  final HttpErrorInfo errorInfo = new HttpErrorInfo(httpStatus, path, message);
  final ObjectMapper mapper = new ObjectMapper();

  try {
    // 예외 정보를 response에 넣어주는 로직
    response.setContentType("application/json; charset=UTF-8");
    response.getWriter().write(mapper.writeValueAsString(errorInfo));
    response.setStatus(httpStatus);
  } catch (IOException e) {
    log.error("응답 작성 실패: {}", e.getMessage(), e);
  }
}
```